### PR TITLE
Fix a typo in migration example

### DIFF
--- a/Modern Hooks/Improvements Over Adam's Hooks.md
+++ b/Modern Hooks/Improvements Over Adam's Hooks.md
@@ -164,7 +164,7 @@ The equivalent modern hooks mod would look something like
 
 local mod = ::Hooks.register(::MyMod.ID, ::MyMod.Version, ::MyMod.Name);
 mod.require("mod_msu >= 1.0.0");
-mod.conflictsWith("mod_bad_mod");
+mod.conflictWith("mod_bad_mod");
 
 mod.queue(">mod_msu", "<mod_swifter", function(){
 	mod.hook("scripts/ui/global/data_helper", function(q) {


### PR DESCRIPTION
There is no "conflictsWith" method in the Mod object.
